### PR TITLE
fix(ci): ignore npm cache in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - node --version
   - npm --version
+  - npm cache clean
   - npm install
 
 test_script:


### PR DESCRIPTION
Often `npm install` in AppVeyor fails with error:

```
Error: EPERM: operation not permitted, rename
'C:\Users\appveyor\AppData\Roaming\npm-cache\core-js\2.4.1\package.tgz.2
558232453' ->
'C:\Users\appveyor\AppData\Roaming\npm-cache\core-js\2.4.1\package.tgz'
npm ERR!     at Error (native)
```

To ignore npm cache need run `npm cache clean`.