### PR TITLE
perf(glob): there is no need to sort files

### DIFF
--- a/lib/write-artifact.js
+++ b/lib/write-artifact.js
@@ -65,7 +65,12 @@ module.exports = (artifact, options) => {
         });
     }).then(() => {
         return new Promise((resolve, reject) => {
-            const readStream = globStream.create(patterns, { cwd: root, base: root, dot: options.dotFiles });
+            const readStream = globStream.create(patterns, {
+                cwd: root,
+                base: root,
+                dot: options.dotFiles,
+                nosort: true
+            });
             const writeStream = artifact.tar
                 ? new TarStream(dest, { gzip: artifact.gzip, emptyFiles: options.emptyFiles })
                 : new FileCopyStream(dest, { emptyFiles: options.emptyFiles });


### PR DESCRIPTION
In my project scan time with sort:

```
real   	0m31.072s
user   	0m30.033s
sys    	0m7.219s
```

Without sort:

```
real   	0m25.002s
user   	0m24.458s
sys    	0m6.432s
```