### PR TITLE
fix(copy): should not ignore dirs

### DIFF
--- a/lib/streams/copy-stream.js
+++ b/lib/streams/copy-stream.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 
+const mkdirp = require('mkdirp');
 const copy = require('copy');
 
 module.exports = class CopyStream extends stream.Writable {
@@ -29,11 +30,17 @@ module.exports = class CopyStream extends stream.Writable {
                 });
             }
 
-            if (stats.isDirectory() || !this._emptyFiles && stats.size === 0) {
+            if (!this._emptyFiles && stats.size === 0) {
                 return callback();
             }
 
-            copy.one(filename, this._dest, { srcBase: file.cwd }, callback);
+            if (stats.isDirectory()) {
+                const dirname = path.join(this._dest, path.relative(file.cwd, filename));
+
+                mkdirp(dirname, callback);
+            } else {
+                copy.one(filename, this._dest, { srcBase: file.cwd }, callback);
+            }
         });
     }
 };

--- a/test/streams/copy-stream.test.js
+++ b/test/streams/copy-stream.test.js
@@ -77,19 +77,18 @@ test('should copy dir with subdirs', async t => {
     t.deepEqual(files, ['file-1.txt', 'file-2.txt']);
 });
 
-test('should ignore directory chunk', async t => {
+test('should copy directory without files', async t => {
     mockFs({
         'source-dir': {
-            'file-1.txt': 'Hi!',
             'sub-dir': { 'file-2.txt': 'Hello!' }
         }
     });
 
-    await copyFiles(['file-1.txt', 'sub-dir']);
+    await copyFiles(['sub-dir/']);
 
     const files = fs.readdirSync(path.join(dest, 'source-dir'));
 
-    t.deepEqual(files, ['file-1.txt']);
+    t.deepEqual(files, ['sub-dir']);
 });
 
 test('should copy source file of symlink', async t => {

--- a/test/write-artifact/dest-dir.test.js
+++ b/test/write-artifact/dest-dir.test.js
@@ -10,15 +10,15 @@ const writeArtifact = promisify(require('../../lib/write-artifact'));
 
 test.afterEach(() => mockFs.restore());
 
-test('should create empty dir', async t => {
+test('should create dest dir', async t => {
     mockFs({
         'source-dir': {}
     });
 
-    await writeArtifact({ dest: 'dest-dir', includes: ['source-dir/**'] });
+    await writeArtifact({ dest: 'dest-dir', includes: ['source-dir/'] });
     const files = fs.readdirSync('dest-dir');
 
-    t.deepEqual(files, []);
+    t.deepEqual(files, ['source-dir']);
 });
 
 test('should create dir by depth path', async t => {
@@ -26,7 +26,7 @@ test('should create dir by depth path', async t => {
         'source-dir': {}
     });
 
-    await writeArtifact({ dest: './path/to/dest-dir/', includes: ['source-dir/**'] });
+    await writeArtifact({ dest: './path/to/dest-dir/', includes: ['source-dir/'] });
     const stats = fs.statSync('./path/to/dest-dir/');
 
     t.true(stats.isDirectory());


### PR DESCRIPTION
If pattern contains path to directory without files need copy this dir without files.

**Example**

Pattern:

```
path/to/file
path/to/empty-dir/
path/to/dir/**
```

Actual:

```
path/to/file
path/to/dir/file-1
path/to/dir/file-2
```

Expected:

```
path/to/file
path/to/empty-dir/
path/to/dir/file-1
path/to/dir/file-2
```