### PR TITLE
fix(tar): should not ignore dirs

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -52,16 +52,19 @@ module.exports = class TarStream extends stream.Writable {
                 });
             }
 
-            if (stats.isDirectory() || !this._emptyFiles && stats.size === 0) {
+            if (!this._emptyFiles && stats.size === 0) {
                 return callback();
             }
 
             const relative = path.relative(file.base, filename);
+            const type = stats.isDirectory() ? 'directory' : 'file';
+            const content = type === 'file' ? fs.createReadStream(filename) : '';
 
-            this._archive.append(fs.createReadStream(filename), {
+            this._archive.append(content, {
                 name: relative,
                 mode: stats.mode,
-                date: stats.mtime
+                date: stats.mtime,
+                type: type
             });
 
             callback();

--- a/test/streams/tar-stream.test.js
+++ b/test/streams/tar-stream.test.js
@@ -62,18 +62,17 @@ test('should create tarball with subdirs', async t => {
     t.deepEqual(files, ['sub-dir/file-1.txt', 'sub-dir/file-2.txt']);
 });
 
-test('should ignore directory chunk', async t => {
+test('should include directory without files', async t => {
     mockFs({
         'source-dir': {
-            'file-1.txt': 'Hi!',
             'sub-dir': { 'file-2.txt': 'Hello!' }
         }
     });
 
-    await packFiles(['file-1.txt', 'sub-dir']);
+    await packFiles(['sub-dir/']);
     const files = await extractFiles();
 
-    t.deepEqual(files, ['file-1.txt']);
+    t.deepEqual(files, ['sub-dir/']);
 });
 
 test('should take into account symlink', async t => {


### PR DESCRIPTION
If pattern contains path to directory without files need include this dir without files to tarball.

**Example**

Pattern:

```
path/to/file
path/to/empty-dir/
path/to/dir/**
```

Actual:

```
path/to/file
path/to/dir/file-1
path/to/dir/file-2
```

Expected:

```
path/to/file
path/to/empty-dir/
path/to/dir/file-1
path/to/dir/file-2
```