### PR TITLE
[WIP] perf(tar): not use `fs.stat()`

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -40,34 +40,44 @@ module.exports = class TarStream extends stream.Writable {
     }
     _write(file, encoding, callback) {
         const filename = file.path;
+        const relative = path.relative(file.base, filename);
 
-        fs.stat(filename, (err, stats) => {
-            if (err) {
-                return fs.lstat(filename, lerr => {
+        // try to read file
+        const readable = fs.createReadStream(filename)
+            .once('readable', () => {
+                const state = readable._readableState;
+                const isEmpty = state.length === 0;
+
+                if (!this._emptyFiles && isEmpty) {
+                    return callback();
+                }
+
+                this._archive.append(readable, {
+                    name: relative,
+                    type: 'file'
+                });
+
+                callback();
+            })
+            .once('error', (err) => {
+                // try to read directory
+                if (err.code === 'EBADF' && err.errno === 9) {
+                    this._archive.append('', {
+                        name: relative,
+                        type: 'directory'
+                    });
+
+                    return callback();
+                }
+
+                // maybe it's broken symlink
+                fs.lstat(filename, lerr => {
                     // file not found
                     if (lerr) { return callback(err); }
 
                     // ignore broken symlink
                     callback();
                 });
-            }
-
-            if (!this._emptyFiles && stats.size === 0) {
-                return callback();
-            }
-
-            const relative = path.relative(file.base, filename);
-            const type = stats.isDirectory() ? 'directory' : 'file';
-            const content = type === 'file' ? fs.createReadStream(filename) : '';
-
-            this._archive.append(content, {
-                name: relative,
-                mode: stats.mode,
-                date: stats.mtime,
-                type: type
             });
-
-            callback();
-        });
     }
 };


### PR DESCRIPTION
The call `fs.stat()` reduces performance somewhat, and is completely
unnecessary, unless readdir is presumed to be an untrustworthy
indicator of file existence.

We can handle the error when attempting to read a directory as a file.

**Important:** this broken change. The `mode` and `date` won't be saved for files.

Need to implement in separate task #49.
