### PR TITLE
fix(tar): should't provide stat info

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -62,8 +62,6 @@ module.exports = class TarStream extends stream.Writable {
 
             this._archive.append(content, {
                 name: relative,
-                mode: stats.mode,
-                date: stats.mtime,
                 type: type
             });
 


### PR DESCRIPTION
The `stat` option will be resolved in #49.