### PR TITLE
perf(tar): detect dir by name

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -6,6 +6,21 @@ const stream = require('stream');
 
 const archiver = require('archiver');
 
+/**
+ * Returns `true` if object contains path to directory.
+ *
+ * **Important:** if pattern contains path to directory without last slash (path/to/dir), then returns `false`.
+ *
+ * @param {{path: string, base: string, cwd: string}} file — The glob stream object with file info.
+ *
+ * @returns {Boolean}
+ */
+function isDirectory(file) {
+    const filename = file.path;
+
+    return filename.endsWith('/') || filename.includes('/') && file.base === `${filename}/`;
+}
+
 module.exports = class TarStream extends stream.Writable {
     constructor(dest, options) {
         const defaults = {
@@ -40,6 +55,16 @@ module.exports = class TarStream extends stream.Writable {
     }
     _write(file, encoding, callback) {
         const filename = file.path;
+        const relative = path.relative(file.cwd, filename);
+
+        if (isDirectory(file)) {
+            this._archive.append('', {
+                name: relative,
+                type: 'directory'
+            });
+
+            return callback();
+        }
 
         fs.stat(filename, (err, stats) => {
             if (err) {
@@ -56,7 +81,6 @@ module.exports = class TarStream extends stream.Writable {
                 return callback();
             }
 
-            const relative = path.relative(file.cwd, filename);
             const type = stats.isDirectory() ? 'directory' : 'file';
             const content = type === 'file' ? fs.createReadStream(filename) : '';
 


### PR DESCRIPTION
If path is direcotry (ends with slash) or path is base dir (see glob-parent) we can not use `fs.stat()` to detect dir.

Before this change:

```
real   	1m36.596s
user   	1m38.054s
sys    	0m20.334s
```

After this change:

```
real   	1m26.146s
user   	1m28.172s
sys    	0m16.741s
```