### PR TITLE
perf(tar): read files with stream

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -86,7 +86,9 @@ module.exports = class TarStream extends stream.Writable {
 
             this._archive.append(content, {
                 name: relative,
-                type: type
+                type: type,
+                _stats: stats,
+                size: stats.size
             });
 
             callback();


### PR DESCRIPTION
If no provide stats to `archiver` then stream will be loaded as buffer
(analogue `fs.readFile`).

This slowed the work with large files.

Before this change:

```
real   	1m23.794s
user   	1m26.043s
sys    	0m17.291s
```

After this change:

```
real   	1m7.710s
user   	1m8.288s
sys    	0m6.331s
```