### PR TITLE
fix(fs): large number of files

### DIFF
--- a/lib/streams/copy-stream.js
+++ b/lib/streams/copy-stream.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const stream = require('stream');
 

--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const stream = require('stream');
 

--- a/lib/write-artifact.js
+++ b/lib/write-artifact.js
@@ -3,8 +3,13 @@
 const path = require('path');
 const assert = require('assert');
 
-const globStream = require('glob-stream');
+const proxyquire = require('proxyquire');
 const mkdirp = require('mkdirp');
+const globStream = proxyquire('glob-stream', {
+    'glob': proxyquire('glob', {
+        'fs': require('graceful-fs')
+    })
+});
 
 const TarStream = require('./streams/tar-stream');
 const CopyStream = require('./streams/copy-stream');

--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
     "async-each": "1.0.1",
     "copy": "0.3.0",
     "es6-promisify": "4.1.0",
+    "glob": "5.0.3",
     "glob-stream": "5.3.5",
+    "graceful-fs": "4.1.6",
     "meow": "3.7.0",
-    "mkdirp": "0.5.1"
+    "mkdirp": "0.5.1",
+    "proxyquire": "1.7.10"
   },
   "devDependencies": {
     "ava": "^0.16.0",


### PR DESCRIPTION
Use `graceful-fs` in streams and `glob` to fix error with a large
number of files.

```
Error: ENFILE: file table overflow, open
```