### PR TITLE
fix(tar): handle callbacks

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -40,11 +40,11 @@ module.exports = class TarStream extends stream.Writable {
             });
 
             archive.pipe(output);
-
             archive.on('error', err => this.emit('error', err));
 
             output.once('open', () => this.emit('open'));
             output.once('close', () => this.emit('close'));
+            output.on('error', err => this.emit('error', err));
 
             this._archive = archive;
             this._emptyFiles = opts.emptyFiles;

--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -97,14 +97,15 @@ module.exports = class TarStream extends stream.Writable {
                 return callback();
             }
 
-            this._archive.append(fs.createReadStream(filename), {
+            const readable = fs.createReadStream(filename)
+                .on('end', () => callback());
+
+            this._archive.append(readable, {
                 name: relative,
                 type: 'file',
                 _stats: stats,
                 size: stats.size
             });
-
-            callback();
         });
     }
 };

--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -33,7 +33,7 @@ module.exports = class TarStream extends stream.Writable {
         super({ objectMode: true });
 
         try {
-            const output = fs.createWriteStream(dest);
+            const output = fs.createWriteStream(dest, { autoClose: true });
             const archive = archiver('tar', {
                 gzip: opts.gzip,
                 gzipOptions: typeof gzip === 'object' ? opts.gzip : { level: 1 }
@@ -97,7 +97,7 @@ module.exports = class TarStream extends stream.Writable {
                 return callback();
             }
 
-            const readable = fs.createReadStream(filename)
+            const readable = fs.createReadStream(filename, { autoClose: true })
                 .on('error', callback)
                 .on('end', () => callback());
 

--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -98,6 +98,7 @@ module.exports = class TarStream extends stream.Writable {
             }
 
             const readable = fs.createReadStream(filename)
+                .on('error', callback)
                 .on('end', () => callback());
 
             this._archive.append(readable, {


### PR DESCRIPTION
Without these changes, the archiving with large numbers of files may freeze.
