### PR TITLE
chore(lint): remove `babel-eslint`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
-parser: babel-eslint
-
 parserOptions:
-  ecmaVersion: 6
+  ecmaVersion: 2017
   sourceType: module
 
 env:

--- a/package.json
+++ b/package.json
@@ -42,10 +42,9 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "babel-eslint": "^6.1.2",
     "coveralls": "^2.11.9",
     "es6-promisify": "^4.1.0",
-    "eslint": "^3.0.0",
+    "eslint": "^3.6.0",
     "eslint-config-pedant": "^0.8.0",
     "is-gzip": "^1.0.0",
     "is-tar": "^1.0.0",


### PR DESCRIPTION
ESLint v3.6.0 support ES2017 syantax natively.