### PR TITLE
fix wrong path to lib/patterns

### DIFF
--- a/bin/tartifacts
+++ b/bin/tartifacts
@@ -7,7 +7,7 @@ const path = require('path');
 const meow = require('meow');
 const tartifacts = require('../');
 
-const loadPatterns = require('../lib/load-patterns');
+const loadPatterns = require('../lib/patterns');
 
 const cli = meow(`
     Usage


### PR DESCRIPTION
```
$ tartifacts --help
module.js:328
    throw err;
    ^

Error: Cannot find module '../lib/load-patterns'
    at Function.Module._resolveFilename (module.js:326:15)
    at Function.Module._load (module.js:277:25)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous>
```