### PR TITLE
Ability to configure all the artifacts in the same place using CLI

### DIFF
--- a/bin/tartifacts
+++ b/bin/tartifacts
@@ -2,12 +2,9 @@
 
 'use strict';
 
-const path = require('path');
-
 const meow = require('meow');
 const tartifacts = require('../');
-
-const patterns = require('../lib/patterns');
+const cliHelpers = require('../lib/cli-helpers');
 
 const cli = meow(`
     Usage
@@ -19,10 +16,12 @@ const cli = meow(`
       -p, --patterns  Path to file with include and exclude patterns
       -d, --dest      Path to destination file
       -r, --root      Path to root directory
+      -c, --config    Path to config
 
     Examples
       $ tartifacts --include="lib/**" --exclude="node_modules/" --dest="artifact.tar.gz"
       $ tartifacts --patterns="./path/to/patterns" --dest="artifact.tar.gz"
+      $ tartifacts --config=.config/tartifacts/pull-request.js
 `, {
 	alias: {
         h: 'help',
@@ -31,27 +30,17 @@ const cli = meow(`
         e: 'exclude',
         p: 'patterns',
         d: 'dest',
-        r: 'root'
+        r: 'root',
+        c: 'config'
 	}
 });
 
 const flags = cli.flags;
-const basename = path.basename(flags.dest);
-const artifact = {
-	dest: flags.dest,
-    patterns: flags.patterns && patterns.load(flags.patterns),
-	includes: [].concat(flags.include || []),
-	excludes: [].concat(flags.exclude || []),
-	tar: basename.includes('.tar'),
-	gzip: basename.includes('.gz')
-};
-
-const options = {
-    root: flags.root
-};
 
 if (Object.keys(flags).length === 0) {
     cli.showHelp();
+} else {
+    tartifacts(cliHelpers.getArtifactsInfoList(flags), {
+        root: flags.root
+    });
 }
-
-tartifacts(artifact, options);

--- a/index.js
+++ b/index.js
@@ -22,14 +22,13 @@ module.exports = (artifacts, options) => {
     artifacts || (artifacts = []);
 
     const defaults = {
-        root: process.cwd(),
         dotFiles: true,
         emptyFiles: true,
         emptyDirs: true
     };
     const opts = Object.assign(defaults, options);
 
-    opts.root = path.resolve(opts.root);
+    opts.root = path.resolve(opts.root || process.cwd());
 
     if (!Array.isArray(artifacts)) {
         artifacts = [artifacts];

--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -1,0 +1,36 @@
+'use strict';
+const path = require('path');
+const patterns = require('../lib/patterns');
+
+/**
+ * Returns info about artifacts.
+ *
+ * @param {object} options
+ * @param {string} options.dest
+ * @param {string|string[]} options.patterns
+ * @param {string[]} options.includes
+ * @param {string[]} options.excludes
+ * @param {boolean} options.tar
+ * @param {boolean} options.gzip
+ * @returns {object[]} The artifacts info.
+ */
+const getArtifactsInfoList = (options) => {
+    if (options.config) {
+        return require(path.resolve(options.config));
+    }
+
+    const basename = path.basename(options.dest);
+
+    return [{
+        dest: options.dest,
+        patterns: options.patterns && patterns.load(options.patterns),
+        includes: [].concat(options.include || []),
+        excludes: [].concat(options.exclude || []),
+        tar: basename.includes('.tar'),
+        gzip: basename.includes('.gz')
+    }];
+};
+
+module.exports = {
+    getArtifactsInfoList
+};

--- a/test/cli-helpers/config.fixture.js
+++ b/test/cli-helpers/config.fixture.js
@@ -1,0 +1,16 @@
+module.exports = [
+    {
+        dest: '../report-templates/YxWeb/web4',
+        patterns: []
+    },
+    {
+        dest: '../static/web4',
+        patterns: []
+    },
+    {
+        dest: '../web4.tar.gz',
+        patterns: [],
+        tar: true,
+        gzip: true
+    }
+];

--- a/test/cli-helpers/get-artifacts-info-list.test.js
+++ b/test/cli-helpers/get-artifacts-info-list.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const test = require('ava');
+const path = require('path');
+const getArtifactsInfoList = require('../../lib/cli-helpers').getArtifactsInfoList;
+
+test('should return config content in case of specified within options', t => {
+    const configPath = './test/cli-helpers/config.fixture.js';
+    const artifacts = getArtifactsInfoList({
+        config: configPath,
+        dest: '../web4.tar.gz',
+        patterns: ['*.js', '*.md'],
+        includes: [],
+        excludes: ['node_modules'],
+        tar: true,
+        gzip: true
+    });
+
+    t.is(artifacts, require(path.resolve(configPath)));
+});
+
+test('should return artifacts based on options in case if config not specified', t => {
+    const artifacts = getArtifactsInfoList({
+        dest: '../web4.tar.gz',
+    });
+
+    t.deepEqual(artifacts, [{
+        dest: '../web4.tar.gz',
+        patterns: undefined,
+        includes: [],
+        excludes: [],
+        tar: true,
+        gzip: true
+    }]); 
+});
+
+test('should load patterns if options.patterns is specified', t => {
+    const patternsPath = './test/cli-helpers/patterns.fixtures.js';
+    const artifacts = getArtifactsInfoList({
+        dest: '../web4.tar.gz',
+        patterns: patternsPath
+    });
+
+    t.deepEqual(artifacts, [{
+        dest: '../web4.tar.gz',
+        patterns: require(path.resolve(patternsPath)),
+        includes: [],
+        excludes: [],
+        tar: true,
+        gzip: true
+    }]);
+})

--- a/test/cli-helpers/patterns.fixtures.js
+++ b/test/cli-helpers/patterns.fixtures.js
@@ -1,0 +1,4 @@
+module.exports = [
+    "freeze/*",
+    "!**/*priv.js"
+];


### PR DESCRIPTION
Hi @blond,

First of all thanks for your work! The package is awesome. I'd like to introduce a feature.

If there's a bunch of artifacts it'd be convenient to describe them in the same place:

```js
module.exports = [
    {
        dest: '../foo.tar.gz',
        patterns: ...
    },
    {
        dest: '../bar.tar.gz',
        patterns: ...
    },
    ...
];
```

This pull request adds a special flag `--config`, using it you can specify a path to your config 👆 

```
$ tartifacts --config=.config/tartifacts/pull-request.js
```

If `--config` is specified all the other flags would be ignored. If it's not specified the previous behavior comes to the stage.

Also, I found some bugs (does `v2.0.0-1` work?):

- ~~6aa401bcd8e19f5b6cd08b07ddb2f39a003594a9~~
- 47fa53d6742ac2c0f3cab1976be565c1487bdf8d