### PR TITLE
followSymlinks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ If `true`, tarball file will be gzipped.
 
 To change the compression level pass object with `level` field.
 
+#### artifact.followSymlinks
+
+Type: `boolean`
+
+Default: `false`
+
+Follow symlinked files and directories.
+
+*Note that this can result in a lot of duplicate references in the presence of cyclic links.*
+
 #### artifact.dotFiles
 
 Type: `boolean`

--- a/lib/artifacts/artifact-task.js
+++ b/lib/artifacts/artifact-task.js
@@ -11,6 +11,7 @@ const defaultSettings = {
     gzip: false,
     gzipOptions: { level: 1 },
 
+    followSymlinks: false,
     dotFiles: true,
     emptyFiles: true,
     emptyDirs: true

--- a/lib/artifacts/write-artifact.js
+++ b/lib/artifacts/write-artifact.js
@@ -42,7 +42,7 @@ const writeArtifact = (artifactTask) => {
         dot: artifactSettings.dotFiles,
         nosort: true,
         nodir: !artifactSettings.emptyDirs,
-        follow: true
+        follow: false
     });
     const writeStream = artifactSettings.tar
         ? new TarStream(artifactInfo.path, artifactSettings)

--- a/lib/artifacts/write-artifact.js
+++ b/lib/artifacts/write-artifact.js
@@ -42,14 +42,11 @@ const writeArtifact = (artifactTask) => {
         dot: artifactSettings.dotFiles,
         nosort: true,
         nodir: !artifactSettings.emptyDirs,
-        follow: false
+        follow: artifactSettings.followSymlinks
     });
     const writeStream = artifactSettings.tar
         ? new TarStream(artifactInfo.path, artifactSettings)
-        : new CopyStream(artifactInfo.path, {
-            emptyFiles: artifactSettings.emptyFiles,
-            emptyDirs: artifactSettings.emptyDirs
-        });
+        : new CopyStream(artifactInfo.path, artifactSettings);
 
     return new Promise((resolve, reject) => {
         readStream.on('error', reject);

--- a/lib/fs/copy-symlink.js
+++ b/lib/fs/copy-symlink.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const nativeFs = require('fs');
+const path = require('path');
+
+const pify = require('pify');
+const makeDir = require('make-dir');
+
+const nativeReadlink = pify(nativeFs.readlink);
+const nativeSymlink = pify(nativeFs.symlink);
+
+/**
+ * Copies symlink to destination.
+ *
+ * @param {string} source Path to symbolic link you want to copy.
+ * @param {string} destination Where you want the symbolic link copied.
+ * @param {Object} [options]
+ * @param {Object} [options.fs] Use a custom fs implementation. For example `graceful-fs`.
+ * @returns {Promise}
+ */
+module.exports = (source, destination, options) => {
+    const opts = options || {};
+    const destPath = path.resolve(destination);
+    const destDir = path.dirname(destPath);
+    const readlink = opts.fs ? pify(opts.fs.readlink) : nativeReadlink;
+    const symlink = opts.fs ? pify(opts.fs.symlink) : nativeSymlink;
+
+    return Promise.all([
+        makeDir(destDir, { fs: opts.fs || nativeFs }),
+        readlink(source)
+    ]).then(res => {
+        const target = res[1];
+
+        return symlink(target, destination);
+    });
+};

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    copySymlink: require('./copy-symlink')
+};

--- a/lib/streams/abstract-writable-stream.js
+++ b/lib/streams/abstract-writable-stream.js
@@ -46,6 +46,7 @@ module.exports = class AbstractWritableStream extends stream.Writable {
 
         super({ objectMode: true });
 
+        this._followSymlinks = opts.followSymlinks;
         this._emptyFiles = opts.emptyFiles;
         this._emptyDirs = opts.emptyDirs;
         this._dest = path.resolve(dest);
@@ -105,32 +106,53 @@ module.exports = class AbstractWritableStream extends stream.Writable {
             return callback();
         }
 
-        fs.lstat(filename, (err, stats) => {
+        fs.lstat(filename, (err, lstats) => {
             if (err) {
                 return callback(err);
             }
 
-            const file = Object.assign({ relative, stats }, chunk);
+            const file = Object.assign({ relative, stats: lstats }, chunk);
 
-            if (stats.isDirectory()) {
+            const addDirectory = () => {
                 // ignore empty dir
                 if (!this._emptyDirs) {
                     return callback();
                 }
 
                 return this.addDirectory(file, callback);
-            }
+            };
+            const addFile = () => {
+                // ignore empty file
+                if (!this._emptyFiles && lstats.size === 0) {
+                    return callback();
+                }
 
-            if (stats.isSymbolicLink()) {
+                this.addFile(file, callback);
+            };
+
+            if (lstats.isSymbolicLink()) {
+                if (this._followSymlinks) {
+                    return fs.stat(file.path, (error, stats) => {
+                        if (error) {
+                            return callback(error);
+                        }
+
+                        if (stats.isDirectory()) {
+                            addDirectory();
+                        } else {
+                            addFile();
+                        }
+                    });
+                }
+
                 return this.addSymbolicLink(file, callback);
             }
 
-            // ignore empty file
-            if (!this._emptyFiles && stats.size === 0) {
-                return callback();
+            if (lstats.isDirectory()) {
+                return addDirectory();
             }
 
-            this.addFile(file, callback);
+            addFile();
         });
     }
 };

--- a/lib/streams/abstract-writable-stream.js
+++ b/lib/streams/abstract-writable-stream.js
@@ -73,6 +73,17 @@ module.exports = class AbstractWritableStream extends stream.Writable {
         throw new Error('The `addFile` method is not implemented.');
     }
     /**
+     * Adds symlink to artifact.
+     *
+     * @param {{path: string, relative: string, base: string, cwd: string, stats: fs.Stats}} file — the file info.
+     * @param {function} callback — call this function when processing is complete.
+     * @abstract
+     */
+    // eslint-disable-next-line class-methods-use-this
+    addSymbolicLink(file, callback) { // eslint-disable-line no-unused-vars
+        throw new Error('The `addSymbolicLink` method is not implemented.');
+    }
+    /**
      * Adds file or directory to artifact.
      *
      * @param {{path: string, base: string, cwd: string}} chunk — the file to be added in artifact.
@@ -94,15 +105,9 @@ module.exports = class AbstractWritableStream extends stream.Writable {
             return callback();
         }
 
-        fs.stat(filename, (err, stats) => {
+        fs.lstat(filename, (err, stats) => {
             if (err) {
-                return fs.lstat(filename, lerr => {
-                    // file not found
-                    if (lerr) { return callback(err); }
-
-                    // ignore broken symlink
-                    callback();
-                });
+                return callback(err);
             }
 
             const file = Object.assign({ relative, stats }, chunk);
@@ -114,6 +119,10 @@ module.exports = class AbstractWritableStream extends stream.Writable {
                 }
 
                 return this.addDirectory(file, callback);
+            }
+
+            if (stats.isSymbolicLink()) {
+                return this.addSymbolicLink(file, callback);
             }
 
             // ignore empty file

--- a/lib/streams/copy-stream.js
+++ b/lib/streams/copy-stream.js
@@ -4,8 +4,10 @@ const path = require('path');
 const assert = require('assert');
 
 const fs = require('graceful-fs');
-const makeDir = require('make-dir');
 const cpFile = require('cp-file');
+const makeDir = require('make-dir');
+
+const copySymlink = require('../fs/copy-symlink');
 
 const AbstractWritableStream = require('./abstract-writable-stream');
 
@@ -61,6 +63,20 @@ module.exports = class CopyStream extends AbstractWritableStream {
         const dest = path.join(this._dest, file.relative);
 
         cpFile(file.path, dest)
+            .then(() => callback())
+            .catch(callback);
+    }
+    /**
+     * Adds symlink to artifact.
+     *
+     * @param {{path: string, relative: string, base: string, cwd: string, stats: fs.Stats}} file — the file info.
+     * @param {function} callback — call this function when processing is complete.
+     * @abstract
+     */
+    addSymbolicLink(file, callback) {
+        const dest = path.join(this._dest, file.relative);
+
+        copySymlink(file.path, dest, { fs })
             .then(() => callback())
             .catch(callback);
     }

--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -91,4 +91,23 @@ module.exports = class TarStream extends AbstractWritableStream {
             size: file.stats.size
         });
     }
+    /**
+     * Adds symlink to archive.
+     *
+     * Keeps original path relative to cwd.
+     *
+     * @param {{path: string, relative: string, base: string, cwd: string, stats: fs.Stats}} file — the directory info.
+     * @param {function} callback — call this function when processing is complete.
+     */
+    addSymbolicLink(file, callback) {
+        fs.readlink(file.path, (err, target) => {
+            if (err) {
+                return callback(err);
+            }
+
+            this._archive.symlink(file.relative, target);
+
+            callback();
+        });
+    }
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "glob-stream": "6.1.0",
     "graceful-fs": "4.1.11",
     "make-dir": "1.1.0",
+    "pify": "3.0.0",
     "proxyquire": "1.8.0"
   },
   "devDependencies": {

--- a/test/artifacts/artifact-task/artifact-settings.test.js
+++ b/test/artifacts/artifact-task/artifact-settings.test.js
@@ -35,6 +35,12 @@ test('should create tar.gz artifact with gzip options', t => {
     t.deepEqual(task.settings.gzipOptions, { level: 10 });
 });
 
+test('should create task with follow symlinks', t => {
+    const task = createTask({ followSymlinks: true });
+
+    t.true(task.settings.followSymlinks);
+});
+
 test('should create task with dot files', t => {
     const task = createTask({ dotFiles: true });
 
@@ -51,6 +57,12 @@ test('should create task with empty dirs', t => {
     const task = createTask({ emptyDirs: true });
 
     t.true(task.settings.emptyDirs);
+});
+
+test('should create task without follow symlinks', t => {
+    const task = createTask({ followSymlinks: false });
+
+    t.false(task.settings.followSymlinks);
 });
 
 test('should create task without dot files', t => {

--- a/test/artifacts/artifact-task/defaults.test.js
+++ b/test/artifacts/artifact-task/defaults.test.js
@@ -23,6 +23,7 @@ test('should create artifact with default options', t => {
         gzip: false,
         gzipOptions: { level: 1 },
 
+        followSymlinks: false,
         dotFiles: true,
         emptyFiles: true,
         emptyDirs: true

--- a/test/artifacts/artifact-task/override-settings.test.js
+++ b/test/artifacts/artifact-task/override-settings.test.js
@@ -29,6 +29,12 @@ test('should use gzip options', t => {
     t.deepEqual(task.settings.gzipOptions, { level: 10 });
 });
 
+test('should override followSymlinks setting', t => {
+    const task = new ArtifactTask(createArtifact({ followSymlinks: false }), { followSymlinks: true });
+
+    t.false(task.settings.followSymlinks);
+});
+
 test('should override dotFiles setting', t => {
     const task = new ArtifactTask(createArtifact({ dotFiles: true }), { dotFiles: false });
 

--- a/test/artifacts/artifact-task/settings.test.js
+++ b/test/artifacts/artifact-task/settings.test.js
@@ -34,6 +34,12 @@ test('should create tar.gz artifact with gzip options', t => {
     t.deepEqual(task.settings.gzipOptions, { level: 10 });
 });
 
+test('should create task with follow symlinks', t => {
+    const task = new ArtifactTask(artifact, { followSymlinks: true });
+
+    t.true(task.settings.followSymlinks);
+});
+
 test('should create task with dot files', t => {
     const task = new ArtifactTask(artifact, { dotFiles: true });
 
@@ -50,6 +56,12 @@ test('should create task with empty dirs', t => {
     const task = new ArtifactTask(artifact, { emptyDirs: true });
 
     t.true(task.settings.emptyDirs);
+});
+
+test('should create task without follow symlinks', t => {
+    const task = new ArtifactTask(artifact, { followSymlinks: false });
+
+    t.false(task.settings.followSymlinks);
 });
 
 test('should create task without dot files', t => {

--- a/test/artifacts/write-artifact/symlink.test.js
+++ b/test/artifacts/write-artifact/symlink.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const test = require('ava');
+const mockFs = require('mock-fs');
+
+const writeArtifact = require('../../../lib/artifacts').writeArtifact;
+
+test.afterEach(() => mockFs.restore());
+
+test('should include symlink to file by default', async t => {
+    mockFs({
+        'file.txt': 'Hi!',
+        'source-dir': {
+            'symlink.txt': mockFs.symlink({
+                path: path.join('..', 'file.txt')
+            })
+        }
+    });
+
+    await writeArtifact({ name: 'artifact-dir', patterns: 'source-dir/**' });
+
+    const link = fs.readlinkSync(path.join('artifact-dir', 'source-dir', 'symlink.txt'));
+
+    t.is(link, path.join('..', 'file.txt'));
+});
+
+test('should include symlink to dir by default', async t => {
+    mockFs({
+        'dir': {
+            'file.txt': 'Hi!'
+        },
+        'source-dir': {
+            'symdir': mockFs.symlink({
+                path: path.join('..', 'dir')
+            })
+        }
+    });
+
+    await writeArtifact({ name: 'artifact-dir', patterns: 'source-dir/**' });
+
+    const link = fs.readlinkSync(path.join('artifact-dir', 'source-dir', 'symdir'));
+
+    t.is(link, path.join('..', 'dir'));
+});

--- a/test/artifacts/write-artifact/symlink.test.js
+++ b/test/artifacts/write-artifact/symlink.test.js
@@ -45,3 +45,39 @@ test('should include symlink to dir by default', async t => {
 
     t.is(link, path.join('..', 'dir'));
 });
+
+test('should follow symlink to file', async t => {
+    mockFs({
+        'file.txt': 'Hi!',
+        'source-dir': {
+            'symlink.txt': mockFs.symlink({
+                path: path.join('..', 'file.txt')
+            })
+        }
+    });
+
+    await writeArtifact({ name: 'artifact-dir', patterns: 'source-dir/**' }, { followSymlinks: true });
+
+    const contents = fs.readFileSync(path.join('artifact-dir', 'source-dir', 'symlink.txt'), 'utf-8');
+
+    t.is(contents, 'Hi!');
+});
+
+test('should follow symlink to dir', async t => {
+    mockFs({
+        'dir': {
+            'file.txt': 'Hi!'
+        },
+        'source-dir': {
+            'symdir': mockFs.symlink({
+                path: path.join('..', 'dir')
+            })
+        }
+    });
+
+    await writeArtifact({ name: 'artifact-dir', patterns: 'source-dir/**' }, { followSymlinks: true });
+
+    const contents = fs.readFileSync(path.join('artifact-dir', 'source-dir', 'symdir', 'file.txt'), 'utf-8');
+
+    t.is(contents, 'Hi!');
+});

--- a/test/fs/copy-symlink.test.js
+++ b/test/fs/copy-symlink.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const test = require('ava');
+const mockFs = require('mock-fs');
+
+const copySymlink = require('../../lib/fs').copySymlink;
+
+test.afterEach(() => mockFs.restore());
+
+test('should throw error if file is not found', t => {
+    mockFs({});
+
+    t.throws(copySymlink('file.txt', 'symlink2.txt'));
+});
+
+test('should throw error if file is not symlink', async t => {
+    mockFs({
+        'file.txt': ''
+    });
+
+    t.throws(copySymlink('file.txt', 'symlink2.txt'));
+});
+
+test('should create symlink', async t => {
+    mockFs({
+        'file.txt': '',
+        'symlink.txt': mockFs.symlink({
+            path: 'file.txt'
+        })
+    });
+
+    await copySymlink('symlink.txt', 'symlink2.txt');
+
+    t.is(fs.readlinkSync('symlink2.txt'), 'file.txt');
+});
+
+test('should create dir', async t => {
+    mockFs({
+        'file.txt': '',
+        'symlink.txt': mockFs.symlink({
+            path: 'file.txt'
+        })
+    });
+
+    await copySymlink('symlink.txt', path.join('dir', 'symlink2.txt'));
+
+    t.deepEqual(fs.readdirSync('dir'), ['symlink2.txt']);
+});
+
+test('should not create dir if already exists', async t => {
+    mockFs({
+        'file.txt': '',
+        'symlink.txt': mockFs.symlink({
+            path: 'file.txt'
+        }),
+        'dir': {}
+    });
+
+    await copySymlink('symlink.txt', path.join('dir', 'symlink2.txt'));
+
+    t.deepEqual(fs.readdirSync('dir'), ['symlink2.txt']);
+});
+
+test('should not change target path', async t => {
+    mockFs({
+        'file.txt': '',
+        'symlink.txt': mockFs.symlink({
+            path: 'file.txt'
+        })
+    });
+
+    await copySymlink('symlink.txt', path.join('dir', 'symlink2.txt'));
+
+    t.is(fs.readlinkSync(path.join('dir','symlink2.txt')), 'file.txt');
+});
+
+test('should use specified fs', async t => {
+    mockFs({
+        'file.txt': '',
+        'symlink.txt': mockFs.symlink({
+            path: 'file.txt'
+        })
+    });
+
+    const userFs = {
+        readlink: (file, cb) => cb(null, 'fake_target'),
+        symlink: fs.symlink,
+        mkdir: fs.mkdir,
+        stat: fs.stat
+    };
+
+    await copySymlink('symlink.txt', 'symlink2.txt', { fs: userFs });
+
+    t.is(fs.readlinkSync('symlink2.txt'), 'fake_target');
+});


### PR DESCRIPTION
* **Major change**: now symlinks will not be changed into files or directories.
* Added `followSymlinks`: follow symlinked files and directories. If symlink is broken, tartifacts falls with error.