### PR TITLE
Keep x flag in file mode while create tar

### DIFF
--- a/lib/streams/tar-stream.js
+++ b/lib/streams/tar-stream.js
@@ -87,6 +87,9 @@ module.exports = class TarStream extends AbstractWritableStream {
         this._archive.append(readable, {
             name: file.relative,
             type: 'file',
+            // We keep original behaviour for node-archiver (0o644 by default for files)
+            // but add `x` flags for executables
+            mode: 0o644 | (0o111 & file.stats.mode),
             _stats: file.stats,
             size: file.stats.size
         });


### PR DESCRIPTION
For now 0o111 get lost.
This path fixes this behaviour and keeps x for executables.